### PR TITLE
Make sure the URL *starts* with http(s):// instead of checking if the URL contains it.

### DIFF
--- a/SignURLs/src/net/willhastings/SignURLs/CustomFunction.java
+++ b/SignURLs/src/net/willhastings/SignURLs/CustomFunction.java
@@ -42,7 +42,7 @@ public class CustomFunction
 		}
 		else if(!linkExists(lineText))
 		{
-			if(URL.toLowerCase().contains("http://"))
+			if(URL.toLowerCase().startsWith("http://") || URL.toLowerCase().startsWith("https://"))
 			{
 				link.put(lineText, URL);
 				if(newLink) SignURLs.addLink(lineText, URL);


### PR DESCRIPTION
This will prevent broken links when you have a URL that contains http:// but does not start with it. Also, support https:// so you don't get http://https://example.com/.
